### PR TITLE
Prevent can_view from raising errors for incompatible formats

### DIFF
--- a/ckanext/unfold/plugin.py
+++ b/ckanext/unfold/plugin.py
@@ -51,7 +51,7 @@ class UnfoldPlugin(p.SingletonPlugin):
         }
 
     def can_view(self, data_dict: types.DataDict) -> bool:
-        return unf_utils.get_adapter_for_resource(data_dict["resource"]) is not None
+        return unf_utils.get_adapter_for_resource(data_dict["resource"], raise_error=False) is not None
 
     def view_template(self, context: types.Context, data_dict: types.DataDict) -> str:
         return "unfold_preview.html"

--- a/ckanext/unfold/plugin.py
+++ b/ckanext/unfold/plugin.py
@@ -46,12 +46,11 @@ class UnfoldPlugin(p.SingletonPlugin):
             "icon": "archive",
             "schema": get_preview_schema(),
             "iframed": False,
-            "always_available": True,
             "default_title": tk._("Unfold"),
         }
 
     def can_view(self, data_dict: types.DataDict) -> bool:
-        return unf_utils.get_adapter_for_resource(data_dict["resource"], raise_error=False) is not None
+        return unf_utils.get_adapter_for_resource(data_dict["resource"]) is not None
 
     def view_template(self, context: types.Context, data_dict: types.DataDict) -> str:
         return "unfold_preview.html"

--- a/ckanext/unfold/utils.py
+++ b/ckanext/unfold/utils.py
@@ -178,6 +178,9 @@ def get_archive_tree(
         return cached_tree
 
     adapter_instance = get_adapter_for_resource(resource)(resource, resource_view)
+    if adapter_instance is None:
+        res_format = resource["format"].lower()
+        raise unf_exception.UnfoldError(f"No adapter for `{res_format}` archives")
 
     archive_tree = adapter_instance.build_archive_tree()
 
@@ -189,7 +192,6 @@ def get_archive_tree(
 
 def get_adapter_for_resource(
     resource: dict[str, Any],
-    raise_error: bool = True
 ) -> type[unf_adapters.BaseAdapter] | None:
     res_format = resource["format"].lower()
 
@@ -203,8 +205,6 @@ def get_adapter_for_resource(
         return adapter
 
     if res_format not in unf_adapters.adapter_registry:
-        if raise_error:
-            raise unf_exception.UnfoldError(f"No adapter for `{res_format}` archives")
         return None
 
     return unf_adapters.adapter_registry[res_format]

--- a/ckanext/unfold/utils.py
+++ b/ckanext/unfold/utils.py
@@ -177,11 +177,12 @@ def get_archive_tree(
     if cache_enabled and cached_tree:
         return cached_tree
 
-    adapter_instance = get_adapter_for_resource(resource)(resource, resource_view)
-    if adapter_instance is None:
+    adapter_cls = get_adapter_for_resource(resource)
+    if adapter_cls is None:
         res_format = resource["format"].lower()
         raise unf_exception.UnfoldError(f"No adapter for `{res_format}` archives")
 
+    adapter_instance = adapter_cls(resource, resource_view)
     archive_tree = adapter_instance.build_archive_tree()
 
     if cache_enabled:

--- a/ckanext/unfold/utils.py
+++ b/ckanext/unfold/utils.py
@@ -189,7 +189,8 @@ def get_archive_tree(
 
 def get_adapter_for_resource(
     resource: dict[str, Any],
-) -> type[unf_adapters.BaseAdapter]:
+    raise_error: bool = True
+) -> type[unf_adapters.BaseAdapter] | None:
     res_format = resource["format"].lower()
 
     for _, adapter in get_adapter_for_resource_signal.send(resource):
@@ -202,6 +203,8 @@ def get_adapter_for_resource(
         return adapter
 
     if res_format not in unf_adapters.adapter_registry:
-        raise unf_exception.UnfoldError(f"No adapter for `{res_format}` archives")
+        if raise_error:
+            raise unf_exception.UnfoldError(f"No adapter for `{res_format}` archives")
+        return None
 
     return unf_adapters.adapter_registry[res_format]

--- a/ckanext/unfold/utils.py
+++ b/ckanext/unfold/utils.py
@@ -204,7 +204,4 @@ def get_adapter_for_resource(
 
         return adapter
 
-    if res_format not in unf_adapters.adapter_registry:
-        return None
-
-    return unf_adapters.adapter_registry[res_format]
+    return unf_adapters.adapter_registry.get(res_format)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ckanext-unfold"
-version = "2.0.1"
+version = "2.0.2"
 description = "Provides previews for multiple archive formats"
 authors = [
     {name = "DataShades", email = "datashades@linkdigital.com.au"},


### PR DESCRIPTION
Updated get_adapter_for_resource to return None.
can_view now safely checks if a resource has a compatible adapter without
raising exceptions, ensuring unfold view creation only for supported formats.